### PR TITLE
Add additional licensing information to /system/helper/utf8.php

### DIFF
--- a/upload/system/helper/utf8.php
+++ b/upload/system/helper/utf8.php
@@ -231,6 +231,8 @@ function utf8_substr($string, $offset, $length = null) {
 * @see utf8_from_unicode
 * @see http://www.unicode.org/reports/tr21/tr21-5.html
 * @see http://dev.splitbrain.org/view/darcs/dokuwiki/inc/utf8.php
+* @license GNU Library or Lesser General Public License version 2.0 (LGPLv2)
+* @link http://phputf8.sourceforge.net/api//utf8/strings/_utf8_native_core_php.html
 * @package utf8
 * @subpackage strings
 */
@@ -489,6 +491,8 @@ function utf8_strtolower($string) {
 * @see utf8_from_unicode
 * @see http://www.unicode.org/reports/tr21/tr21-5.html
 * @see http://dev.splitbrain.org/view/darcs/dokuwiki/inc/utf8.php
+* @license GNU Library or Lesser General Public License version 2.0 (LGPLv2)
+* @link http://phputf8.sourceforge.net/api//utf8/strings/_utf8_native_core_php.html
 * @package utf8
 * @subpackage strings
 */


### PR DESCRIPTION
It appears that the originally discovered missing licensing information wasn't the full extent of it; I've discovered two _more_ functions in the opencart codebase which appear to be reused without attribution (again) from another open source project, without obtaining the consent of the original author to remove said license/attribution.

For reference, the original code by Andreas Gohr (@splitbrain on github), under the Dokuwiki project, is available here on sourceforge: 
http://phputf8.sourceforge.net/api//__filesource/fsource_utf8_strings_nativecore.php.html#a195

While there are _minor_ differences (such as the use of a static var over a global and a count call moved to a less optimal location), a trained reader will observe that the functions are almost identical.  Knowing the history of opencart's lead developer and their use of third-party code without attribution, it should be assumed that this code is also third party and should be attributed.  As such, this PR adds the docblocks used in the above link to provide documentation and attribution information for the two functions used in `/system/helper/utf8.php` along with an `@ license` line stating the function's license and an `@ link` line providing the URL to the original function itself.

Licensing compatibility should _not_ be a concern as the php-utf8 library that Dokuwiki created above is recorded as being licensed under the LGPL 2.0; this license is documented on GNU.org as being forwards-compatible with the GNU GPLv3.  The license of the originating project can be verified by viewing the license stated on Sourceforge, available here: http://sourceforge.net/projects/phputf8/

Unfortunately, I cannot open a pull request against opencart itself - [which is _still_ using these two functions](https://github.com/opencart/opencart/blob/71ef63419d5fe6b3b0e0ade3eb43154fba8bfeff/upload/system/helper/utf8.php#L53) in all branches without attribution even after the lead developer @danielkerr claimed to have removed all infringing code.  If another wishes to open a similar pull request against [opencart/opencart](https://github.com/opencart/opencart/) to replace the missing copyright information, that would probably be ideal.
